### PR TITLE
Added arrow scrolling and view reset

### DIFF
--- a/BeatSaberTrackEditor/BeatSaberTrackEditor.pde
+++ b/BeatSaberTrackEditor/BeatSaberTrackEditor.pde
@@ -187,13 +187,12 @@ void keyPressed(){
     if (controlPressed){
       sequencer.resetView();
     }else{
-    if(shiftPressed && sequencer.getY() >= 10){
-      sequencer.scrollY(-10);  
-    }else{
-      sequencer.scrollY(-1);
+      if(shiftPressed && sequencer.getY() >= 10){
+        sequencer.scrollY(-10);  
+      }else{
+        sequencer.scrollY(-1);
+      }
     }
-    }
-
   }
 
   if(key == ' '){

--- a/BeatSaberTrackEditor/BeatSaberTrackEditor.pde
+++ b/BeatSaberTrackEditor/BeatSaberTrackEditor.pde
@@ -175,6 +175,27 @@ void keyPressed(){
     }
   }
   
+  if (keyCode == UP){
+    if(shiftPressed){
+      sequencer.scrollY(10);
+    }else{
+      sequencer.scrollY(1);
+    }
+  }
+  
+  if (keyCode == DOWN && sequencer.getY() >= 0){
+    if (controlPressed){
+      sequencer.resetView();
+    }else{
+    if(shiftPressed && sequencer.getY() >= 10){
+      sequencer.scrollY(-10);  
+    }else{
+      sequencer.scrollY(-1);
+    }
+    }
+
+  }
+
   if(key == ' '){
     if(shiftPressed){
       sequencer.stop();

--- a/BeatSaberTrackEditor/TrackSequencer.pde
+++ b/BeatSaberTrackEditor/TrackSequencer.pde
@@ -118,6 +118,10 @@ class TrackSequencer extends GUIElement{
     return (int)(time * (gridSize / (beatsPerBar/2)));
   }
   
+  public void resetView(){
+    this.setY(startYPosition);
+  }
+  
   public void scrollY(float scroll){
     if(scroll > 0){
       this.setY((int)(this.getY() + scroll * gridSize));


### PR DESCRIPTION
Added the ability to scroll with up/down arrows by 1 unit (10 if shift is held)
Ctrl+Down arrow automatically resets the view to default. 
I didn't want to override ctrl+space but it's a logical option.