### PR TITLE
Bug #4: Used approximation to calculate averageCounter instead of absolute.

### DIFF
--- a/BeatSaberTrackEditor/Waveform.pde
+++ b/BeatSaberTrackEditor/Waveform.pde
@@ -83,7 +83,7 @@ class Waveform extends GUIElement {
       average += abs(samplesVal[i] * widthScale) ; // sample are low value so we increase the size to see them
       
       thisRemainder = (i % (sizeOfAvg));
-      if ((i % (sizeOfAvg)) < lastRemainder) {
+      if (thisRemainder < lastRemainder) {
         avgCounter++;
         float newVal = average / sizeOfAvg;
         sampleAverage.append(newVal);

--- a/BeatSaberTrackEditor/Waveform.pde
+++ b/BeatSaberTrackEditor/Waveform.pde
@@ -77,10 +77,13 @@ class Waveform extends GUIElement {
     int average=0;
     
     int avgCounter = 0;
+    float lastRemainder = 9999;
+    float thisRemainder;
     for (int i = 0; i < samplesVal.length; ++i) {
       average += abs(samplesVal[i] * widthScale) ; // sample are low value so we increase the size to see them
       
-      if ( (i % (sizeOfAvg)) == 0) {
+      thisRemainder = (i % (sizeOfAvg));
+      if ((i % (sizeOfAvg)) < lastRemainder) {
         avgCounter++;
         float newVal = average / sizeOfAvg;
         sampleAverage.append(newVal);
@@ -88,6 +91,7 @@ class Waveform extends GUIElement {
           maxSize = newVal;
         average = 0;
       }
+      lastRemainder = thisRemainder;
     } 
     
     println("avgCounter  : "   + avgCounter);


### PR DESCRIPTION
Instead of a boolean "if (i % (sizeOfAvg)) == 0)" I'm keeping track of the remainder "i % (sizeOfAvg)". When that variable is less than it was the previous loop, it's either zero, or it's closest approximation, so it starts a loop.

(This is my first pull request, If I'm doing something wrong let me know)